### PR TITLE
fixed typo in pr_master_cg

### DIFF
--- a/predict_and_recompute/numerical_experiments/cg_variants/pr_cg.py
+++ b/predict_and_recompute/numerical_experiments/cg_variants/pr_cg.py
@@ -65,7 +65,7 @@ def pr_master_cg(A,b,x0,max_iter,variant='',callbacks=[],**kwargs):
         p_k    =  r_k   +    b_k * p_k1
         s_k    =  A     @ p_k
         mu_k   =  p_k   @ s_k 
-        del_k  =  r_k   @ st_k
+        del_k  =  r_k   @ s_k
         gam_k  =  s_k   @ s_k
         nu_k   =  r_k   @ r_k
         a_k    =  nu_k / mu_k


### PR DESCRIPTION
Hi, I just tried to run the code and found a small typo in the `pr_master_cg` function. It should be `s_k` instead of its preconditioned counterpart `st_k`, which should only be used in the preconditioned variant `pr_master_pcg`.